### PR TITLE
Add acronym definition guidelines to agent instructions

### DIFF
--- a/ai/global-context/AGENTS.md
+++ b/ai/global-context/AGENTS.md
@@ -18,6 +18,11 @@
 - No jargon-for-jargon's-sake, no hedging filler ("it's worth noting that...", "essentially", "basically")
 - If a shorter word works, use it; if a precise term is needed, use it and don't water it down
 
+### Define acronyms
+- Define acronyms the first time you use them: "Bottom Line Up Front (BLUF)", "Time To First Token (TTFT)"
+- Skip definition only for acronyms that are universally obvious (e.g., FYI, JSON, HTML, URL, CPU)
+- When in doubt, define it — err on the side of defining
+
 ### No value-laden language
 - Neutral, analytical tone — no "obviously", "unfortunately", "clearly", "diabolical", "elegant"
 - Subjective judgments belong only when I ask for them, and should be labeled as opinion


### PR DESCRIPTION
## Summary
Added a new section to the agent guidelines documenting best practices for defining acronyms in generated content.

## Changes
- Added "Define acronyms" section to AGENTS.md with clear rules for acronym usage
- Requires defining acronyms on first use with the format: "Full Term (ACRONYM)"
- Establishes exception for universally recognized acronyms (FYI, JSON, HTML, URL, CPU)
- Encourages erring on the side of definition when uncertain about audience familiarity

## Details
This guideline promotes clarity and accessibility by ensuring that specialized terminology is explained to readers who may not be familiar with domain-specific acronyms, while avoiding unnecessary definitions for truly universal terms.

https://claude.ai/code/session_015K6YYT3L3yeBBkzhthXogb