### PR TITLE
Add calendar context to agent guidelines

### DIFF
--- a/ai/global-context/AGENTS.md
+++ b/ai/global-context/AGENTS.md
@@ -67,3 +67,8 @@
   - DON'T: add documentation that repeats the code
   - DO: document inputs, outputs, and include examples
 
+## Personal context
+
+### Calendar
+- Whenever you're answering prompts involving my calendar, remember to include the "Mark & Kaye Shared Calendar"
+


### PR DESCRIPTION
This change adds personal context guidance to the agent documentation to ensure consistent handling of calendar-related queries.

**Summary**
Added a new "Personal context" section to the AGENTS.md documentation with specific instructions for calendar-related prompts.

**Key changes**
- Added "Personal context" section to global agent guidelines
- Documented that calendar queries should include the "Mark & Kaye Shared Calendar" in responses

**Implementation details**
This guidance ensures that when agents respond to prompts involving the user's calendar, they will consistently reference the shared calendar resource, improving the relevance and completeness of calendar-related assistance.

https://claude.ai/code/session_01UYNVDvkqRCbLN4Ri94CbLf