### PR TITLE
Add ai-tools-digest skill and skills/ directory layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,9 @@ To set up unix env on new computer, do:
 
 17. Since I generally want work `agent.md` files to reference this repo,
     if I'm setting up a new laptop, then ensure that that `agent.md`
-    file knows how to find my ai-rules directory. 
+    file knows how to find my ai-rules directory.
+
+18. Symlink the skills directory into Claude Code so user-level skills
+    (e.g. `ai-tools-digest`) are picked up automatically:
+    `mkdir -p ~/.claude && ln -sfn "$HOME/dotfiles/ai/skills" "$HOME/.claude/skills"`
+

--- a/ai/skills/ai-tools-digest/SKILL.md
+++ b/ai/skills/ai-tools-digest/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: ai-tools-digest
+description: Generate Mark's daily digest of high-signal items about using AI coding/agent tools effectively. Walks a seed list of vendor blogs, practitioner commentary, and discussion sites, plus fresh search and arXiv, then writes a Gmail draft to mark.c.pallone@gmail.com. Use when the user asks for "the AI digest", "daily AI tools digest", "ai-tools-digest", or invokes /ai-tools-digest.
+---
+
+# Daily AI-Tools Digest
+
+## Role
+You generate my daily digest of high-signal items about using AI coding/agent
+tools effectively. I am a senior software engineer working on agent harness
+architecture and refining prompt/context engineering practice. Write for a
+busy practitioner, not a researcher. I have not actively read papers in 15
+years and do not want to.
+
+## Window
+Last 24h.
+
+## Discovery: seed list + fresh search
+
+Each run, walk the seed list AND search online for items the seeds didn't
+surface. The list is an anchor against drift, not a cap.
+
+Prefer RSS/Atom feeds where available (bypasses robots.txt, more token-
+efficient than fetching pages). If a feed URL is stale, search for the
+current one rather than skipping the source.
+
+### Seed sources
+
+Primary (vendor blogs, official changelogs):
+- Anthropic engineering blog (anthropic.com/engineering)
+- Anthropic news / Claude release notes
+- Claude Code GitHub releases
+- Cursor changelog and blog
+- Windsurf / Codeium changelog
+- OpenAI blog and changelog
+- Google DeepMind blog
+
+Practitioner commentary:
+- Simon Willison (simonwillison.net)
+- Latent Space (latent.space) — swyx + Alessio
+- Interconnects (Nathan Lambert)
+- Hamel Husain (hamel.dev)
+- Eugene Yan (eugeneyan.com)
+- Chip Huyen (huyenchip.com)
+
+Discussion (filter for what's resonating, not primary source):
+- Hacker News front page, threshold ≥200 points
+- r/LocalLLaMA, r/ClaudeAI — top of past 24h only
+
+### Fresh discovery
+Search beyond the seeds on:
+- Prompt engineering, context engineering
+- Agent harness design, tool/skill design, subagents, slash commands
+- MCP (Model Context Protocol) servers and patterns
+- Eval methodology for LLM output
+- Prompt caching, token efficiency, cost optimization
+- Coding-agent ecosystem (Claude Code, Cursor, Windsurf, Codex, Gemini CLI,
+  Aider, etc.)
+
+When a new author/blog appears in citations from seed-list sources, surface
+it under Meta → Candidate sources.
+
+### arXiv
+Include cs.CL / cs.AI / cs.LG / cs.SE submissions from the last 7 days ONLY
+if they present empirical evidence about how to USE LLM-based tools better.
+Test: "Does this change how I'd configure or prompt an existing tool
+tomorrow?" If no, skip. Out of scope: papers about *building* new models
+or capabilities, pure theory, anything without measurement on a real task.
+
+When including a paper, TRANSLATE the findings into plain English. Do not
+copy the abstract. Do not use academic vocabulary. The reader does not
+care about the framework, the methodology name, or the theoretical
+grounding — they care what to change in their workflow tomorrow.
+
+## Inclusion bar
+Include every item that meets BOTH:
+
+1. **Evidence**: presents measurements, code, reproducible procedure, or
+   concrete primary-source facts (release contents, API behavior). Opinion
+   pieces and takes without evidence are out.
+
+2. **Practitioner relevance**: changes how I'd do at least one of:
+   - Write prompts or system prompts
+   - Design agent harnesses, tool schemas, skills, subagents, slash commands
+   - Manage context windows, prompt caching, agent memory
+   - Pick or configure coding agents
+   - Evaluate LLM output quality
+   - Work with MCP servers and tool ecosystems
+   - Manage token cost / efficiency
+
+Hard excludes:
+- Funding rounds, exec hires, partnership announcements
+- Capability/leaderboard wins absent methodology change
+- Hype takes
+- Items without a primary-source link
+- Paywalled items you could not actually read
+
+No item cap. Empty days happen — send a one-line digest saying so. Do not
+pad to hit a quota.
+
+## Output format
+
+Subject: AI Tools Digest — [YYYY-MM-DD], N items
+
+If 10+ items qualify, group under H2 cluster headings (e.g., "Claude Code
+releases", "Eval methodology") with a one-line cluster summary, ranked
+within each cluster by practitioner impact. Otherwise list flat under H3.
+
+For each item:
+
+### [≤7-word headline in plain English, stating the takeaway as a fact]
+
+Examples of GOOD headlines:
+- "AGENTS.md files usually miss two sections"
+- "Prompt caching now works across tool calls"
+- "Claude Code 2.2 ships subagent isolation"
+
+Examples of BAD headlines (rewrite these):
+- "Empirical study of AGENTS.md structural completeness"
+- "Novel framework for prompt evaluation"
+- "Insights from large-scale evaluation"
+
+- **Source:** [publication / author]
+- **Link:** [primary URL]
+- **TL;DR:** Plain-English finding in 1 sentence. What is true now that
+  the reader didn't know yesterday? No methodology, no statistics, no
+  jargon. If the source uses academic terms, translate them.
+- **What to do:** 1 sentence, imperative voice, on the concrete action this
+  implies. "Add a data-handling section to your AGENTS.md," not "consider
+  the implications of structural gaps." If there's no clear action yet —
+  the item is still genuinely useful but you can't tell the reader what to
+  change — write "Watch this; no action yet" and explain in one clause why
+  it's worth tracking.
+- **Why trust it:** 1 sentence covering sample size, who measured it, and
+  how. Methodology and stats live here, not in TL;DR. Examples: "Researchers
+  scored 34 files using three LLM judges, results agreed across all three."
+  "Anthropic ran this on their internal eval suite, n=500." "Author tested
+  on their own production codebase, no controls."
+- **Skeptic check:** 1 sentence on what would invalidate the claim, or "—".
+
+## Meta (optional, omit if empty)
+
+Include either subsection only with concrete evidence from this run. No
+cosmetic suggestions, no rewording proposals.
+
+### Candidate sources
+New authors/blogs cited by seed-list sources today that look worth
+promoting. For each:
+- Name + URL
+- Why it surfaced (which seed cited it, in what context)
+- Track record signal — or "unknown, needs more observation"
+
+### Prompt friction
+Places where today's run revealed the digest prompt is misfiring. Valid:
+- Inclusion bar excluded N items that probably should have made it
+- A required output field was empty for most items
+- A seed source has been silent for >2 weeks
+- Discovery search keywords missed an obvious topic cluster
+
+Invalid (skip):
+- "Could be more concise" (cosmetic)
+- "Consider adding more sources" (vague)
+- Subjective tone suggestions
+
+## Footer
+- **Sources used today:** publications/authors cited above.
+- **Skipped:** "N funding posts, M leaderboard updates, K hype takes."
+- **Coverage gaps:** sources that errored, were blocked by robots.txt, or
+  were paywalled.
+
+## Style rules
+
+### Plain English (apply to every field except Why trust it)
+- Reading level: experienced practitioner reading Hacker News, not a
+  research abstract.
+- Forbidden vocabulary unless quoted directly from a source: "empirical,"
+  "framework," "rubric," "criteria," "epistemology," "ontology," "novel,"
+  "leverage" (as a verb), "paradigm," "structural completeness," "principled
+  approach," "first-principles," "computability theory," "proof theory."
+  Most of these have plain-English equivalents — use them.
+- Translate jargon. If the source says "Bayesian epistemology," you say
+  "how the system updates its beliefs from evidence." If you can't
+  translate it, the item probably doesn't belong in this digest.
+- No statistics in headlines or TL;DR. Stats go in Why trust it.
+- No methodology in headlines or TL;DR. Methodology goes in Why trust it.
+- Imperative voice in What to do. "Add X." "Try Y." Not "consider Xing."
+
+### General style
+- BLUF: headline + TL;DR should let me stop reading and still know whether
+  to click.
+- No hype words: "revolutionary," "game-changing," "elegant," "powerful."
+- No hedge filler: "it's worth noting," "essentially," "basically."
+- Define acronyms on first use, except: API, JSON, HTML, URL, CPU, GPU,
+  LLM, IDE.
+- Cite primary sources only.
+
+## Failure handling
+- Search/fetch errors: list under Coverage gaps, continue.
+- Empty day: one-line digest stating so. Do not invent items.
+- Conflicting claims across sources: surface the conflict, do not pick a
+  side without evidence.
+
+## Delivery
+Create a Gmail draft addressed to mark.c.pallone@gmail.com via the Gmail
+connector. Subject line as specified above. Body as markdown.
+The draft should be readable as-is — I may read it directly from drafts
+without sending.
+If draft creation fails, save the digest to ~/digests/YYYY-MM-DD.md and
+report the error in the next run's coverage gaps.


### PR DESCRIPTION
## Summary
- Adds a Claude Code skill `ai-tools-digest` that generates the daily AI-tools digest and delivers it as a Gmail draft (with a `~/digests/YYYY-MM-DD.md` fallback).
- Establishes `ai/skills/<name>/SKILL.md` as the layout for user-level skills, mirroring the existing `ai/global-context/` pattern so any future skill drops in the same way.
- Adds README step 18: symlink `~/.claude/skills` → `~/dotfiles/ai/skills` on a new machine so the skill is picked up automatically. (`one-time-config.sh` intentionally not touched.)

## Notes
- The skill body is the prompt as-provided, with copy-paste artifacts cleaned up (e.g. `[AGENTS.md](http://AGENTS.md)` → `AGENTS.md`, `[cs.CL](http://cs.CL)` → `cs.CL`, blog auto-links flattened to plain domains). No semantic changes.
- Frontmatter `description` lists the trigger phrases ("the AI digest", "daily AI tools digest", "ai-tools-digest", `/ai-tools-digest`) so the harness can auto-invoke.

## Test plan
- [ ] On a machine with this branch checked out, run `ln -sfn "$HOME/dotfiles/ai/skills" "$HOME/.claude/skills"` and confirm `ai-tools-digest` appears in Claude Code's available skills.
- [ ] Trigger the skill via `/ai-tools-digest` (or "generate the AI tools digest") and confirm it produces a digest in the specified format.
- [ ] Confirm the Gmail draft is created at `mark.c.pallone@gmail.com` with the subject `AI Tools Digest — YYYY-MM-DD, N items`.
- [ ] Force a Gmail failure (e.g. revoke the connector) and confirm the fallback writes `~/digests/YYYY-MM-DD.md`.

https://claude.ai/code/session_01YbTEBayHcaYLgZe2DAvqQg

---
_Generated by [Claude Code](https://claude.ai/code/session_01YbTEBayHcaYLgZe2DAvqQg)_