### PR TITLE
Make personal AGENTS.md canonical home for writing + engineering stan…

### DIFF
--- a/ai/global-context/AGENTS.md
+++ b/ai/global-context/AGENTS.md
@@ -2,38 +2,75 @@
 
 ## Communication
 
-### Bottom Line Up Front (BLUF)
-- Lead with the answer, conclusion, or recommendation in the first sentence
-- Title/header (≤7 words) and opening line should let me stop reading and still have what I need
-- Supporting detail comes after, in inverted-pyramid order: most decision-relevant first
-- Bad: "I looked into the Kafka retention question and there are several factors..."
-- Good: "**Increase retention to 7 days.** Current 3-day window is causing replay failures during weekend incidents because..."
-- **"BLUF" names the technique; don't print it.** Never write "BLUF", "BLUF:", "Bottom Line Up Front", or "TL;DR" as a label in output — readers may not know it. Lead with the bottom line as plain text, as in the Good example above.
+Write like a CIA analyst briefing the President. Every response should help busy people make decisions quickly. Five rules, all in service of one goal: **say exactly what you mean, as quickly and clearly as possible.**
 
-### Support claims with evidence
-- Every non-obvious assertion needs a reason, source, or example beneath it. Always include links where feasible. 
-- Don't expect me to take your word for it; show the chain
+### 1. Bottom Line Up Front (BLUF)
 
-### Precise but simple language
-- Say exactly what you mean, in the fewest plain words that preserve precision
-- No jargon-for-jargon's-sake, no hedging filler ("it's worth noting that...", "essentially", "basically")
-- If a shorter word works, use it; if a precise term is needed, use it and don't water it down
+Your title/header (5–7 words) and first sentence (2–3 lines) must contain ALL the information the reader needs to grasp the key point and make a decision. Someone should be able to read just that and move on.
+
+**Good:**
+> **Death Star Plans Show Key Vulnerability:** The plans show a fatal flaw that a massed X-Wing assault could exploit.
+
+**Bad:**
+> **New Information About Death Star:** Princess Leia has sent us the plans, which will help our military planning.
+
+The first conveys the essential insight. The second is vague and buries the point.
+
+**"BLUF" names the technique; don't print it.** Structure the response this way — first sentence carries the point — but never write "BLUF", "BLUF:", "Bottom Line Up Front", "TL;DR", or similar labels in reader-facing output. Readers may not know the term. State the bottom line as plain text, exactly as the Good example above does.
+
+### 2. Support your argument with evidence
+
+After the BLUF, provide sub-arguments and evidence in **inverted pyramid** order:
+
+- Most critical supporting point first
+- Then secondary details
+- Then background/context
+
+Use bullets over dense paragraphs; each bullet should stand alone as a discrete fact. Every non-obvious assertion needs a reason, source, or example beneath it — always include links where feasible. Don't expect me to take your word for it; show the chain.
+
+### 3. Precise but simple language
+
+Say exactly what you mean — no more, no less. In the fewest plain words that preserve precision. If a shorter word works, use it; if a precise term is needed, use it and don't water it down. No jargon-for-jargon's-sake, no hedging filler ("it's worth noting that...", "essentially", "basically").
+
+| Problem | Example |
+|---------|---------|
+| Too complex | "Technical specifications indicate a diminutive exhaust location would commence a series of explosions" |
+| Not precise enough | "Shooting into a hole would destroy it" |
+| Too many words | A full paragraph explaining every system when one sentence suffices |
+| **Just right** | "A shot entering a small thermal exhaust port would start a chain reaction and destroy the Death Star" |
+
+### 4. No value-laden language
+
+Avoid subjective judgments and emotionally charged terms. They undermine credibility and bias the reader toward emotional rather than logical responses. Neutral, analytical tone — no "obviously", "unfortunately", "clearly", "diabolical", "elegant". Subjective judgments belong only when I ask for them, and should be labeled as opinion.
+
+**Neutral (good):**
+> We know there are at least some in the Klingon military that seek to sabotage the negotiations.
+
+**Value-laden (bad):**
+> There are diabolical elements seeking to destroy us. They need to be stopped at all costs.
+
+### 5. Convey uncertainty as risk, not vibes
+
+Terms like "probably", "likely", "may", and "could" are ambiguous — different readers interpret them differently. Does "likely" mean 50%? 80%? 99%? Plans differ dramatically based on interpretation.
+
+Prefer to state the risk, its rough magnitude, and what to do about it:
+- State what you know vs. don't know
+- Focus on the risk and the action it implies
+- Avoid false precision — don't say "80% chance" unless you can justify the calculation; if you have a probability estimate, say how you got it; if you don't, say so
+
+**Ambiguous:**
+> The Sith will likely wipe out the Jedi within a week.
+
+**Better — focus on risk and action:**
+> We don't know how quickly the Sith will wipe the Jedi out, but their forces are stronger and we need to plan for a rout in the near-term.
+
+**Engineering example:**
+> Untested on Java 21 virtual threads — main risk is thread-pinning under JNI calls. Worth a smoke test before rollout.
 
 ### Define acronyms
 - Define acronyms the first time you use them: "Cross-Origin Resource Sharing (CORS)", "Time To First Token (TTFT)"
 - Skip definition only for acronyms that are universally obvious (e.g., FYI, JSON, HTML, URL, CPU)
 - When in doubt, define it — err on the side of defining
-
-### No value-laden language
-- Neutral, analytical tone — no "obviously", "unfortunately", "clearly", "diabolical", "elegant"
-- Subjective judgments belong only when I ask for them, and should be labeled as opinion
-
-### Convey uncertainty as risk, not vibes
-- Avoid bare "likely / probably / may / could" — they're ambiguous
-- Prefer: state the risk, its rough magnitude, and what to do about it
-- If you have a probability estimate, say how you got it; if you don't, say so
-- Bad: "This will probably work"
-- Good: "Untested on Java 21 virtual threads — main risk is thread-pinning under JNI calls. Worth a smoke test before rollout."
 
 ### General style
 - Terse, direct, high-signal; no sycophancy, no hedging, no fluff
@@ -60,15 +97,110 @@ Whenever you explain how code or a technology works — asked or not — use tea
 - Dig until you hit ground truth: read the code, run the check, cite the source. No plausible-sounding guesses
 - Don't trust documentation. Verify assertions in docs against code or other primary sources when feasible; flag any you couldn't verify
 
-## Interaction
+## Engineering writing standards
 
-### Context-switching aid
-- Start interactive responses with a **bold header** summarizing what I asked
-- I context-switch a lot and may not remember the topic when I return
+Applies to all technical prose: commit messages, CL/PR descriptions, READMEs, incident reports, design docs, code comments. Treat violations as defects in generated output. (The BLUF and no-hedging rules under Communication also apply — this section adds engineering-specific specifics on top.)
 
-### When you make an error
-- If you make an error, if feasible tell me what context you were missing and how I could've done better to ensure you had that context
-- Goal is to improve the feedback loop, not assign blame — name the specific missing input (a file, a config value, a constraint), not vague "more detail"
+### Core rules
+
+**State tradeoffs.** If a solution has a cost, say so. "This fixed latency but increased memory usage by 30%" beats "This improved performance."
+
+**Use numbers.** Vague claims are noise. "Reduced failures significantly" means nothing. "Went from 5 failures/week to less than 1/month" is a fact.
+
+**Be direct about what's broken.** "Builds were failing regularly for mysterious reasons" is honest. "There were some intermittent stability issues" hides the problem.
+
+**No corporate filler.** Cut "leveraging," "synergies," "enabling stakeholders," "driving alignment," "moving the needle."
+
+### Prohibited openers
+
+Never start with:
+- "In this document / article / post..."
+- "As part of..."
+- "In order to..."
+- "This commit updates / changes / improves..."
+- "I'm happy to report..."
+- "It's important to note..."
+
+### Skimmable structure
+
+Readers scan before they read. Structure for that.
+
+- **Headings are descriptive, not generic.** "Challenge: Flaky Workspace Cleanup" beats "Problem Statement." "Why We Chose Perforce" beats "Background."
+- **Lead each section with the key fact**, not with context. Context is a paragraph 2 thing.
+- **Bold key concepts**, not random words. One or two per section max.
+- **Bullets for lists of facts or steps** — not for everything. Prose for reasoning.
+- **Concrete numbers beat adjectives.** "100 build nodes," "went from 5 failures/week to <1/month," "builds take 47 minutes end-to-end."
+
+### Format by context
+
+| Context | Rules |
+|---|---|
+| Commit messages | Imperative verb, what changed, optionally why. One line. Body only if non-obvious. |
+| CL / PR descriptions | One punchy lead sentence. Bullets for multi-part changes. Bold key concepts. |
+| READMEs | Structured for skimming. Headers are descriptive ("Running tests locally"), not generic ("Usage"). |
+| Incident reports / postmortems | Lead with impact and timeline. Findings before analysis. State what you don't know. |
+| Design docs | State the decision at the top. Alternatives section is mandatory. Tradeoffs over sales pitch. |
+| Code comments | Explain *why*, not *what*. Target experienced engineers. Skip obvious explanations. |
+| Slack / chat | No pleasantries before the question. Get to it. |
+
+### Incident and postmortem writing
+
+This is where bad writing does the most damage. Be especially rigorous here.
+
+- **Lead with impact**: "Production builds were down for 47 minutes on 2026-03-10. Root cause: P4 workspace quota exhausted."
+- **Timeline before analysis**: list what happened and when, then explain why.
+- **State what you don't know**: "We don't yet know why the cleanup job stopped running." Don't paper over gaps.
+- **No passive voice for failures**: "The cleanup job failed to run" not "Cleanup was not performed."
+- **No humor, no lightness.** Someone is in pain. Stay professional and factual.
+- **Action items must have owners and dates**: "Fix quota monitoring — owner: @alice, due: 2026-03-17."
+
+### Commit message format
+
+```
+<verb> <what> [in <where>]
+
+<optional: why or context, not what. bullets for multi-part.>
+```
+
+Examples:
+- `Fix race condition in P4 workspace naming`
+- `Add retry logic to Horde job poller — previously dropped failures silently`
+- `Remove stale branch cleanup job — superseded by JIRA-driven automation`
+
+Not:
+- `Update code` (too vague)
+- `This commit fixes the issue with...` (filler opener)
+- `Misc fixes` (never)
+
+### CL / PR description format
+
+```
+<one sentence: what changed and why>
+
+- **Key change**: detail
+- **Key change**: detail
+```
+
+### Honest framing patterns
+
+These are good. Use them:
+
+- "This works well for X but hasn't been tested on Y."
+- "We chose A over B because of Z. The tradeoff is..."
+- "We don't fully understand why this fixed it, but the failure rate dropped from X to Y."
+- "This is a workaround. The real fix requires..."
+- "50 dependencies × 99% uptime = 60% pipeline reliability. Math is the enemy here."
+
+### Quality bar
+
+Before submitting, scan for:
+- Does the first sentence contain the main point?
+- Are there any numbers that should be there but aren't?
+- Is there hedging language that can be removed?
+- Does each bullet / paragraph carry new information?
+- Would a skimming engineer understand the key facts in 10 seconds?
+
+Remove anything that doesn't survive that scan.
 
 ## Coding 
 
@@ -91,4 +223,3 @@ Whenever you explain how code or a technology works — asked or not — use tea
 
 ### Calendar
 - Whenever you're answering prompts involving my calendar, remember to include the "Mark & Kaye Shared Calendar"
-


### PR DESCRIPTION
…dards

Absorbs general guidance previously duplicated in the Riot-hosted AGENTS.md so mmm stops concatenating the same rules twice into every tool's context file.

- Rewrote Communication with the verbose Five Rules (BLUF, evidence, precise language, no value-laden language, uncertainty-as-risk) + examples
- Added Engineering writing standards section (trimmed from Riot's "Concise Engineer" — dropped BLUF/no-hedging dups, kept formats, prohibited openers, incident rules, quality bar)
- Preserved personal-only nuances: include-links, banned-word list, Java 21 virtual-threads uncertainty example

Pairs with the Riot dotfiles PR that deletes the moved content — both must land together since mmm joins the two files.