### PR TITLE
Add guidance to verify local clone currency before reading source

### DIFF
--- a/ai/global-context/AGENTS.md
+++ b/ai/global-context/AGENTS.md
@@ -97,6 +97,9 @@ Whenever you explain how code or a technology works — asked or not — use tea
 - Dig until you hit ground truth: read the code, run the check, cite the source. No plausible-sounding guesses
 - Don't trust documentation. Verify assertions in docs against code or other primary sources when feasible; flag any you couldn't verify
 
+### Check the clone is current before reading source
+- Before checking source for answers, check whether the local clone is out of date with the remote. If it is, stop and tell me.
+
 ## Engineering writing standards
 
 Applies to all technical prose: commit messages, CL/PR descriptions, READMEs, incident reports, design docs, code comments. Treat violations as defects in generated output. (The BLUF and no-hedging rules under Communication also apply — this section adds engineering-specific specifics on top.)


### PR DESCRIPTION
## Summary
Added a new guideline to the agent instructions emphasizing the importance of checking whether the local repository clone is current with the remote before relying on source code for answers.

## Changes
- Added new section "Check the clone is current before reading source" under the source verification guidelines
- Instructs agents to verify the local clone is up-to-date with remote before using it as a source of truth
- If the clone is out of date, agents should stop and notify the user rather than proceeding with potentially stale information

## Rationale
This ensures that when agents cite source code or verify assertions against the codebase, they're working with current information. Stale local clones could lead to incorrect answers based on outdated code, undermining the "ground truth" verification principle established in the preceding guidelines.

https://claude.ai/code/session_01M1rpvpgDgt5fm3m1mQcwcC