### PR TITLE
Add cloud setup script to sync Claude config into web sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,32 @@ To set up unix env on new computer, do:
 18. Since I generally want work `agent.md` files to reference this repo,
     if I'm setting up a new laptop, then ensure that that `agent.md`
     file knows how to find my ai-rules directory. 
+
+19. **Claude Code on the web (claude.ai/code):** a web session clones only the
+    project repo, so `~/.claude` from my laptop is absent. To sync this repo's
+    `ai/` tree into `~/.claude` on every session, paste this bootstrap into the
+    environment's "Setup script" field:
+
+    ```bash
+    #!/bin/bash
+    git clone --depth 1 https://github.com/mpallone/dotfiles.git /tmp/dotfiles || true
+    [ -f /tmp/dotfiles/ai/cloud-setup.sh ] && bash /tmp/dotfiles/ai/cloud-setup.sh || true
+    ```
+
+    It clones this (public) repo and runs `ai/cloud-setup.sh`, which copies
+    `ai/global-context/AGENTS.md` -> `~/.claude/CLAUDE.md` and everything under
+    `ai/skills/` -> `~/.claude/skills/`. Keeping the script in the repo means
+    future edits are just a `git push`.
+
+    - Prerequisite: the environment's network policy must allow `github.com`
+      (the "Trusted" policy). Under the "None" network policy the clone fails.
+      `git` is pre-installed.
+    - Refresh caveat: setup scripts run on the FIRST session, then the filesystem
+      is snapshotted and the script is SKIPPED on later sessions — so `~/.claude`
+      is frozen until the cache rebuilds (editing the setup script or allowed
+      hosts, or ~7-day expiry). To force a refresh after pushing dotfiles changes,
+      re-save the setup script in the environment UI.
+    - Known limitation: `ai/skills/daily-ai-tools-digest.md` is copied but is NOT
+      an invocable skill — Claude Code only discovers `<name>/SKILL.md`
+      directories, so a bare `.md` under `skills/` is ignored. Wrapping it as a
+      proper skill directory is a separate follow-up.

--- a/ai/cloud-setup.sh
+++ b/ai/cloud-setup.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# cloud-setup.sh — install personal Claude config into ~/.claude for
+# Claude Code on the web (claude.ai/code).
+#
+# A web session clones only the project repo, so ~/.claude from your laptop
+# is absent. This mirrors this dotfiles repo's ai/ tree into ~/.claude so
+# your global instructions and skills are present in every cloud session:
+#
+#   ai/global-context/AGENTS.md  ->  ~/.claude/CLAUDE.md   (CC reads CLAUDE.md)
+#   ai/skills/<entry>            ->  ~/.claude/skills/<entry>
+#
+# Invoked by the environment "Setup script" via a bootstrap that clones this
+# repo first (see README).
+#
+# Design: copies (not symlinks) because the cloud VM is snapshotted and
+# throwaway; always exits 0 so a failure never blocks session start, but
+# prints [ok]/[warn] per step so nothing fails silently. Idempotent.
+#
+# Usage (from a checkout of this repo):  bash ai/cloud-setup.sh
+#
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"   # this is ai/
+SKILLS_SRC="$SCRIPT_DIR/skills"
+CONTEXT_SRC="$SCRIPT_DIR/global-context/AGENTS.md"
+
+CLAUDE_DIR="$HOME/.claude"
+SKILLS_DST="$CLAUDE_DIR/skills"
+CONTEXT_DST="$CLAUDE_DIR/CLAUDE.md"
+
+ok()   { echo "[cloud-setup] [ok]   $*"; }
+warn() { echo "[cloud-setup] [warn] $*" >&2; }
+
+mkdir -p "$SKILLS_DST"
+
+# --- Global instructions: AGENTS.md -> ~/.claude/CLAUDE.md -----------------
+if [ -f "$CONTEXT_SRC" ]; then
+  if cp "$CONTEXT_SRC" "$CONTEXT_DST"; then
+    ok "global context -> $CONTEXT_DST"
+  else
+    warn "failed to copy $CONTEXT_SRC -> $CONTEXT_DST"
+  fi
+else
+  warn "global context not found at $CONTEXT_SRC (skipped)"
+fi
+
+# --- Skills: everything under ai/skills/ -> ~/.claude/skills/ --------------
+if [ -d "$SKILLS_SRC" ]; then
+  if cp -a "$SKILLS_SRC/." "$SKILLS_DST/"; then
+    ok "skills -> $SKILLS_DST"
+  else
+    warn "failed to copy skills from $SKILLS_SRC"
+  fi
+else
+  warn "skills dir not found at $SKILLS_SRC (skipped)"
+fi
+
+echo "[cloud-setup] done"
+exit 0


### PR DESCRIPTION
Claude Code on the web clones only the project repo, so ~/.claude from
the laptop is absent. Add ai/cloud-setup.sh to mirror this repo's ai/
tree into ~/.claude at session start:

  - ai/global-context/AGENTS.md -> ~/.claude/CLAUDE.md
  - everything under ai/skills/  -> ~/.claude/skills/

The script copies (not symlinks) since the cloud VM is snapshotted and
ephemeral, and always exits 0 so a failure never blocks session start,
printing [ok]/[warn] per step so nothing fails silently. Idempotent.

Document the setup-script bootstrap, the github.com network prereq, the
snapshot refresh caveat, and the daily-ai-tools-digest.md skill caveat
in the README.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WnGyeJ5HoHoBHnDYynPR48