### PR TITLE
Re-add cloud-setup.sh as a second (redundant) cloud-sync path

### DIFF
--- a/.github/skills-release-notes.md
+++ b/.github/skills-release-notes.md
@@ -32,8 +32,9 @@ Whenever you change it, update it manually in **both** places:
 
 - **Claude app:** paste it into **Settings → Profile → your personal preferences /
   custom instructions.**
-- **Cloud Claude Code:** no auto-sync exists — paste the relevant guidance into the
-  work repo's `CLAUDE.md` (or wherever that repo reads its context).
+- **Cloud Claude Code:** if you've wired up the `ai/cloud-setup.sh` bootstrap in the
+  environment's Setup script, AGENTS.md is pulled in automatically (re-save the setup
+  script to refresh). Otherwise, paste the guidance into the work repo's `CLAUDE.md`.
 
 _(Local Claude Code gets AGENTS.md via `mmm`, so that one's already covered.)_
 

--- a/README.md
+++ b/README.md
@@ -62,5 +62,8 @@ it's distributed to every Claude surface from there:
 - **claude.ai app + Cloud Claude Code** — the app has no upload API, so a GitHub Action
   auto-builds ready-to-upload skill ZIPs (published to the `skills-latest` release);
   you drop them into Settings → Skills. That one upload also feeds cloud Code.
+- **Cloud Claude Code (alternative)** — `ai/cloud-setup.sh`, run from the environment's
+  Setup script, pulls skills **and** AGENTS.md straight from this repo. Redundant with the
+  zip path above (they can drift) — kept on purpose.
 
 The intent, the "why", and the exact steps live in [`ai/README.md`](ai/README.md).

--- a/ai/README.md
+++ b/ai/README.md
@@ -17,9 +17,11 @@ ai/
 ├── skills/                      # one <name>/SKILL.md per skill
 │   ├── teach-me/
 │   ├── jira-sprint-cleanup/
+│   ├── morning-plan/
 │   ├── mmm-deploy/              # local-machine tool (needs the mmm CLI)
 │   ├── update-repos/            # local-machine tool (operates on local git repos)
 │   └── daily-ai-tools-digest.md # loose note, NOT a skill (no <name>/SKILL.md dir)
+├── cloud-setup.sh               # Cloud Code setup script: copies AGENTS.md + skills into ~/.claude
 └── scripts/package_skills.sh    # builds claude.ai-app-ready skill ZIPs
 ```
 
@@ -28,7 +30,7 @@ ai/
 | Surface | Mechanism | Manual step? |
 | :-- | :-- | :-- |
 | **Local Claude Code** (laptop) | `mmm deploy` (marks-markdown-manager) distributes context + skills to each tool's dir | none (run `mmm`) |
-| **Cloud Claude Code** (claude.ai/code) | inherits your **enabled app skills** via the app-upload bridge (below) | none |
+| **Cloud Claude Code** (claude.ai/code) | **either** the app-upload bridge (enabled app skills auto-load) **or** the `cloud-setup.sh` setup script (pulls skills **and** AGENTS.md from this repo) — see [Cloud Claude Code setup script](#cloud-claude-code-setup-script) | none |
 | **claude.ai app** (regular chats) | manual ZIP upload under Settings; the ZIPs are auto-built for you (see below) | one upload per changed skill |
 
 ### Why the app is the odd one out
@@ -57,11 +59,50 @@ reserved words (`claude`/`anthropic`), `description` non-empty ≤1024 chars wit
 tags. `mmm-deploy` and `update-repos` are **excluded** — they're local-machine tools that
 can't run in the app/cloud sandbox (they'd load but fail if invoked).
 
+## Cloud Claude Code setup script
+
+`ai/cloud-setup.sh` is a **second, independent** way to get this repo's config into
+cloud sessions. A cloud session clones only the *project* repo, so `~/.claude` is
+absent; the script clones this dotfiles repo and copies:
+
+- `ai/global-context/AGENTS.md` → `~/.claude/CLAUDE.md`
+- everything under `ai/skills/` → `~/.claude/skills/`
+
+Wire it up **once per environment**: paste this bootstrap into the environment's
+**Setup script** field (claude.ai/code → environment settings):
+
+```bash
+#!/bin/bash
+git clone --depth 1 https://github.com/mpallone/dotfiles.git /tmp/dotfiles || true
+[ -f /tmp/dotfiles/ai/cloud-setup.sh ] && bash /tmp/dotfiles/ai/cloud-setup.sh || true
+```
+
+- **Prerequisite:** the environment's network policy must allow `github.com` (the
+  **Trusted** policy). Under **None**, the clone fails (the script still exits 0, so the
+  session starts, just without the sync). `git` is pre-installed.
+- **Refresh caveat:** setup scripts run on the FIRST session, then the filesystem is
+  snapshotted and the script is SKIPPED on later sessions — so `~/.claude` is frozen
+  until the cache rebuilds (edit the setup script or allowed hosts, or ~7-day expiry).
+  To force a refresh after pushing dotfiles changes, re-save the setup script in the UI.
+
+### Redundancy — intentional, and it can drift
+
+This path **overlaps** the claude.ai-app zip path: enabled app skills already auto-load
+into cloud sessions, and this script *also* copies skills in. Both are on by choice.
+Consequences accepted:
+
+- **They can drift.** The app serves whatever zip you last uploaded; the script serves
+  this repo's HEAD as of the last snapshot. The same skill can differ between the two.
+- **A skill may show up from both sources** in a cloud session (app-provided **and** the
+  `~/.claude/skills/` copy). Expected and tolerated.
+- The script's edge over the zip path: it also brings **AGENTS.md** (global context, which
+  the zip/bridge does not) and ships **all** skills — including `morning-plan` and the
+  local-only `mmm-deploy` / `update-repos` — not just the app-portable subset.
+
 ## Known limitations / follow-ups
 
-- **Global context (`global-context/AGENTS.md`)** is distributed by `mmm` locally and can
-  be pasted into claude.ai custom instructions for app chats, but has **no automated path
-  into cloud Code** now that the old setup-script approach is retired. Options if it starts
-  to matter: a per-work-repo `CLAUDE.md`, or a minimal cloud setup script.
+- **Global context (`global-context/AGENTS.md`)**: distributed by `mmm` locally, pulled
+  into cloud Code by `cloud-setup.sh` (above), and pasted by hand into claude.ai custom
+  instructions for app chats (no upload API for that surface).
 - **`jira-sprint-cleanup`** needs the Atlassian connector enabled in whatever chat runs it.
 - **`daily-ai-tools-digest.md`** is a loose note, not a skill; nothing packages or ships it.

--- a/ai/cloud-setup.sh
+++ b/ai/cloud-setup.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# cloud-setup.sh — install personal Claude config into ~/.claude for
+# Claude Code on the web (claude.ai/code).
+#
+# A web session clones only the project repo, so ~/.claude from your laptop
+# is absent. This mirrors this dotfiles repo's ai/ tree into ~/.claude so
+# your global instructions and skills are present in every cloud session:
+#
+#   ai/global-context/AGENTS.md  ->  ~/.claude/CLAUDE.md   (CC reads CLAUDE.md)
+#   ai/skills/<entry>            ->  ~/.claude/skills/<entry>
+#
+# Invoked by the environment "Setup script" via a bootstrap that clones this
+# repo first (see ai/README.md).
+#
+# This is a SECOND, independent path to get skills into cloud sessions,
+# redundant with the claude.ai-app zip upload (whose enabled skills also load
+# into cloud sessions). The two can drift; see ai/README.md.
+#
+# Design: copies (not symlinks) because the cloud VM is snapshotted and
+# throwaway; always exits 0 so a failure never blocks session start, but
+# prints [ok]/[warn] per step so nothing fails silently. Idempotent.
+#
+# Usage (from a checkout of this repo):  bash ai/cloud-setup.sh
+#
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"   # this is ai/
+SKILLS_SRC="$SCRIPT_DIR/skills"
+CONTEXT_SRC="$SCRIPT_DIR/global-context/AGENTS.md"
+
+CLAUDE_DIR="$HOME/.claude"
+SKILLS_DST="$CLAUDE_DIR/skills"
+CONTEXT_DST="$CLAUDE_DIR/CLAUDE.md"
+
+ok()   { echo "[cloud-setup] [ok]   $*"; }
+warn() { echo "[cloud-setup] [warn] $*" >&2; }
+
+mkdir -p "$SKILLS_DST"
+
+# --- Global instructions: AGENTS.md -> ~/.claude/CLAUDE.md -----------------
+if [ -f "$CONTEXT_SRC" ]; then
+  if cp "$CONTEXT_SRC" "$CONTEXT_DST"; then
+    ok "global context -> $CONTEXT_DST"
+  else
+    warn "failed to copy $CONTEXT_SRC -> $CONTEXT_DST"
+  fi
+else
+  warn "global context not found at $CONTEXT_SRC (skipped)"
+fi
+
+# --- Skills: everything under ai/skills/ -> ~/.claude/skills/ --------------
+if [ -d "$SKILLS_SRC" ]; then
+  if cp -a "$SKILLS_SRC/." "$SKILLS_DST/"; then
+    ok "skills -> $SKILLS_DST"
+  else
+    warn "failed to copy skills from $SKILLS_SRC"
+  fi
+else
+  warn "skills dir not found at $SKILLS_SRC (skipped)"
+fi
+
+echo "[cloud-setup] done"
+exit 0


### PR DESCRIPTION
Adds back `ai/cloud-setup.sh` so **Cloud Claude Code** can pull skills **and** `AGENTS.md` straight from this repo, as a second path alongside the claude.ai-app zip upload. This is intentionally redundant, and the two paths can drift — documented as such.

## What's added
- **`ai/cloud-setup.sh`** (executable) — clones this repo and copies `ai/global-context/AGENTS.md → ~/.claude/CLAUDE.md` and `ai/skills/* → ~/.claude/skills/`. `set -u`, always exits 0, `[ok]`/`[warn]` per step, idempotent. Verified: syntax OK; dry run against a throwaway `HOME` writes `CLAUDE.md` (12345 bytes) and all skills including the new `morning-plan`.
- Run it via the environment's **Setup script** bootstrap (clone + run) — documented in `ai/README.md`.

## Docs (the redundancy is spelled out)
- **`ai/README.md`** — new "Cloud Claude Code setup script" section: the bootstrap, the `github.com`/Trusted network prereq, the snapshot refresh caveat, and a "Redundancy — intentional, and it can drift" subsection noting the app-zip and setup-script paths overlap, that the same skill can differ between them, that a skill may appear from both sources, and that the script's edge is it also carries `AGENTS.md` and all skills. Surface table + layout updated.
- **Top-level README** — a bullet for the alternative cloud path with the drift note.
- **`.github/skills-release-notes.md`** — the AGENTS.md reminder now notes cloud can auto-pull via the setup script (this also refreshes the `skills-latest` release body on merge, since the notes file is in the workflow's path filter).

## Behavior notes
- The setup script ships **all** skills to cloud (incl. `morning-plan`, and the local-only `mmm-deploy`/`update-repos` which stay dormant there), whereas the app-zip path only ships the app-portable subset. No change to `package_skills.sh` or its allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnGyeJ5HoHoBHnDYynPR48

---
_Generated by [Claude Code](https://claude.ai/code/session_01WnGyeJ5HoHoBHnDYynPR48)_