### PR TITLE
morning-plan: triage all not-done items, not just unlabeled ones

### DIFF
--- a/ai/skills/morning-plan/SKILL.md
+++ b/ai/skills/morning-plan/SKILL.md
@@ -49,9 +49,11 @@ searchJiraIssuesUsingJql
   fields: ["summary", "labels", "status", "parent"]
 ```
 
-Group results by existing bucket label. Items with no bucket label are the
-"unsorted" pile. Present a compact snapshot: yesterday's buckets (from labels)
-plus the unsorted count.
+Group results by existing bucket label — this grouping is only for the
+snapshot, not a filter on who gets interviewed. Present a compact snapshot:
+yesterday's buckets (from labels) plus the total count of open, non-separator
+items. The entire open, non-separator set is the triage queue (see Interview),
+whether or not an item already carries a bucket label.
 
 **Duplicate check**: if two or more open non-separator issues share effectively
 the same summary (typical cause: automation re-created a recurring chore that
@@ -62,8 +64,9 @@ plan with whatever survives cleanup.
 
 ### 2. Interview
 
-Triage every unsorted item; also offer to revisit yesterday's `daily-target`
-leftovers. Rules:
+Triage **every** open (not-done), non-separator item, whether or not it already
+carries a bucket label — nothing is carried over untouched; yesterday's labeled
+items get re-triaged fresh each run. Rules:
 
 - Batches of **at most 3 items** per round, using tappable single-select
   options. Tap options cap at 4, so each question offers: **Daily target /
@@ -73,7 +76,11 @@ leftovers. Rules:
 - **"Mark as done" is an action, not a label**: on selection, immediately
   transition the issue to Done (`transitionJiraIssue`, id `31`) and write no
   bucket label.
-- Embed a suggested bucket in each question, using the heuristic:
+- Embed a suggested bucket in each question, always computed from the heuristic
+  below — independent of any bucket label the item already carries. A stored
+  label never pre-selects the answer; it is only context. You may note an item's
+  current bucket briefly ("currently: aspirational") for context, but the
+  *suggestion* is the heuristic result:
   - **Low-effort must-dos rise to the top** → suggest `daily-target`
     (examples: litter box, trash to curb, cat feeder).
   - **High-effort items and exercise-like items** → suggest `aspirational`.
@@ -87,7 +94,9 @@ leftovers. Rules:
     "(… automation)" tag and ownership changed permanently, remind Mark once
     to edit the generating rule in Jira **Project settings → Automation**.
   - A different bucket name → use it.
-  - "skip" → leave unlabeled, mention it in the final brief.
+  - "skip" → leave the item's current label untouched (an unlabeled item stays
+    unlabeled; an already-labeled item keeps its existing bucket) and mention it
+    in the final brief. Skipping never erases a bucket.
 
 ### 3. Write labels (batched, after the interview)
 
@@ -124,6 +133,7 @@ End with the day's plan, formatted for a phone screen:
   artifact of the day's exact ordering, offer to write it as a comment on the
   `week planning ritual` ticket (or the topmost daily-target item) — don't do
   this unprompted.
-- Don't re-interview items already carrying a bucket label unless Mark asks or
-  their situation obviously changed (e.g., a "(Sunday automation)" item on a
-  new day).
+- Every not-done, non-separator item is re-triaged on every run: a stored
+  bucket label neither suppresses the prompt nor pre-selects the answer (the
+  suggestion is recomputed from the effort heuristic each time). Separators and
+  automation banner rows remain excluded from triage per the rules above.


### PR DESCRIPTION
## What & why

The `morning-plan` skill only interviewed the **"unsorted" pile** — not-done Jira issues with no bucket label. Items that already carried a bucket label (`daily-target`, `prioritize`, `aspirational`, `not-daily-goals`) were skipped, and a guardrail explicitly forbade re-interviewing them. Mark wants the ritual to prompt him for **every not-done item, every time he runs it**, so yesterday's labeled items get re-triaged fresh rather than carried over untouched.

The Read step already fetched the full not-done set (`statusCategory != Done`), so the fix is a scope/wording change in the Interview step plus one guardrail — no query change.

## Changes (`ai/skills/morning-plan/SKILL.md`)

- **Step 1 (Read):** grouping-by-label is now only for the snapshot, not a filter; the whole open, non-separator set is the triage queue.
- **Step 2 (Interview) scope:** triage every open, non-separator item, labeled or not.
- **Step 2 heuristic:** the suggested bucket is always recomputed from the effort heuristic — a stored label never pre-selects the answer (it's only shown as context).
- **Step 2 "skip":** now preserves an item's existing label instead of wiping it (unlabeled stays unlabeled; a labeled item keeps its bucket).
- **Guardrails:** replaced the "don't re-interview items already carrying a bucket label" rule with the new all-items default.

## Decisions confirmed with Mark

- **Fresh effort heuristic** drives the suggestion for already-labeled items (stored label doesn't pre-select).
- **Separators / automation-banner rows stay excluded** from triage — they're clutter, not real tasks.

## Verification

Prose/skill change with no executable surface. Confirmed no remaining references to interviewing only the "unsorted" pile / "leftovers," and the old guardrail is replaced. A live dry-run (running "morning plan" against the Atlassian Rovo connector) is Mark's to run since it writes to Jira.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018kZJhkwbpTsLffkzvr24UB

---
_Generated by [Claude Code](https://claude.ai/code/session_018kZJhkwbpTsLffkzvr24UB)_