### PR TITLE
Package every skill, dropping the app-portable allowlist

### DIFF
--- a/.github/skills-release-notes.md
+++ b/.github/skills-release-notes.md
@@ -1,7 +1,7 @@
 ## 📦 What this is
 
 Auto-built, upload-ready skill ZIPs for the **claude.ai app**. Rebuilt on every
-push to `main`. Currently includes: `teach-me`, `jira-sprint-cleanup`.
+push to `main`. Every skill in the repo gets a zip here automatically.
 
 ---
 
@@ -14,7 +14,8 @@ push to `main`. Currently includes: `teach-me`, `jira-sprint-cleanup`.
    sessions (claude.ai/code) — no separate step.
 
 - 🔁 **When a skill changes:** a fresh zip lands here automatically — just re-upload it.
-- 🔌 `jira-sprint-cleanup` needs your **Atlassian connector** enabled in the chat.
+- 🔌 `jira-sprint-cleanup` and `morning-plan` need your **Atlassian connector** enabled in the chat.
+- 🖥️ `mmm-deploy` and `update-repos` are local-machine tools — they'll upload fine but only work in local Claude Code, not the app/cloud sandbox.
 
 ---
 

--- a/.github/workflows/package-skills.yml
+++ b/.github/workflows/package-skills.yml
@@ -3,13 +3,13 @@
 # WHY: the claude.ai app has no API for uploading custom skills; the only way
 # in is a manual ZIP upload under Settings. This workflow automates everything
 # up to that final drag-and-drop: on every push to main that touches a skill,
-# it validates each app-portable skill's SKILL.md and rebuilds its ZIP, then
+# it validates each skill's SKILL.md and rebuilds its ZIP, then
 # publishes the ZIPs to a rolling "skills-latest" GitHub Release. So the current,
 # valid zips always have a stable download URL — you just grab them and upload.
 # (Uploading a skill to the app also auto-loads it into cloud Claude Code.)
 #
-# The heavy lifting lives in ai/scripts/package_skills.sh (which also defines
-# which skills are app-portable). See ai/README.md for the full architecture.
+# The heavy lifting lives in ai/scripts/package_skills.sh, which packages every
+# skill directory under ai/skills/. See ai/README.md for the full architecture.
 
 name: Package skills for claude.ai
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .DS_Store
+
+# Build output from ai/scripts/package_skills.sh (skill ZIPs; CI rebuilds these).
+dist/

--- a/ai/README.md
+++ b/ai/README.md
@@ -47,8 +47,9 @@ and cloud Code.
 
 ## Automation: the app ZIPs
 
-`ai/scripts/package_skills.sh` builds a validated ZIP for each **app-portable** skill
-(`teach-me`, `jira-sprint-cleanup`) and drops them in `dist/`. The
+`ai/scripts/package_skills.sh` builds a validated ZIP for **every** skill under
+`ai/skills/` (any `<name>/` with a `SKILL.md`) and drops them in `dist/`. There's no
+allowlist — add a skill and it ships automatically. The
 `.github/workflows/package-skills.yml` Action runs it on every push that touches a skill
 and publishes the ZIPs to a rolling **`skills-latest`** GitHub Release. To refresh the
 app after changing a skill: grab the current ZIP from that release and re-upload it under
@@ -56,8 +57,9 @@ app after changing a skill: grab the current ZIP from that release and re-upload
 
 Validation mirrors the app's rules: `name` lowercase-hyphenated ≤64 chars with no
 reserved words (`claude`/`anthropic`), `description` non-empty ≤1024 chars with no XML
-tags. `mmm-deploy` and `update-repos` are **excluded** — they're local-machine tools that
-can't run in the app/cloud sandbox (they'd load but fail if invoked).
+tags. `mmm-deploy` and `update-repos` are packaged too, but they're local-machine tools
+that can't run in the app/cloud sandbox (they'd load but fail if invoked) — upload them
+only if you actually want them visible there.
 
 ## Cloud Claude Code setup script
 
@@ -96,8 +98,9 @@ Consequences accepted:
 - **A skill may show up from both sources** in a cloud session (app-provided **and** the
   `~/.claude/skills/` copy). Expected and tolerated.
 - The script's edge over the zip path: it also brings **AGENTS.md** (global context, which
-  the zip/bridge does not) and ships **all** skills — including `morning-plan` and the
-  local-only `mmm-deploy` / `update-repos` — not just the app-portable subset.
+  the zip/bridge does not). Both paths now ship **all** skills — including the local-only
+  `mmm-deploy` / `update-repos` — so their skill sets match; only AGENTS.md is unique to
+  the script.
 
 ## Known limitations / follow-ups
 

--- a/ai/scripts/package_skills.sh
+++ b/ai/scripts/package_skills.sh
@@ -11,11 +11,12 @@
 # zips always exist and are always valid; the human just downloads + uploads.
 # (One app upload also auto-loads the skill into cloud Claude Code sessions.)
 #
-# Only APP_PORTABLE skills are packaged. mmm-deploy and update-repos are
-# local-machine tools (they need the mmm CLI / your local git repos) and would
-# not function in the claude.ai sandbox, so they are intentionally excluded.
-# The loose ai/skills/daily-ai-tools-digest.md is not a skill directory and is
-# ignored by everything.
+# Every skill directory under ai/skills/ (any <name>/ containing a SKILL.md) is
+# packaged — there is no allowlist, so a newly added skill ships automatically.
+# The loose ai/skills/daily-ai-tools-digest.md is a file, not a skill directory,
+# so it is ignored. Note: mmm-deploy and update-repos are local-machine tools
+# (they need the mmm CLI / your local git repos) and won't function in the
+# claude.ai sandbox, but they are still zipped along with everything else.
 #
 # Validation mirrors the claude.ai custom-skill rules:
 #   name:        lowercase letters/numbers/hyphens, <= 64 chars, not containing
@@ -40,10 +41,6 @@ AI_DIR="$(dirname "$SCRIPT_DIR")"                            # ai
 REPO_ROOT="$(dirname "$AI_DIR")"                             # repo root
 SKILLS_DIR="$AI_DIR/skills"
 DIST_DIR="${DIST_DIR:-$REPO_ROOT/dist}"
-
-# Skills that make sense on the claude.ai app / cloud Code (space-separated).
-# Override with the APP_PORTABLE env var to re-scope or to test validation.
-APP_PORTABLE="${APP_PORTABLE:-teach-me jira-sprint-cleanup}"
 
 ok()   { echo "[package-skills] [ok]   $*"; }
 warn() { echo "[package-skills] [warn] $*" >&2; }
@@ -133,19 +130,12 @@ package_one() {
   fi
 }
 
-# --- Package every portable skill -------------------------------------------
-for skill in $APP_PORTABLE; do
-  package_one "$skill"
-done
-
-# --- Report skills present but intentionally not packaged -------------------
+# --- Package every skill directory under ai/skills/ -------------------------
 for entry in "$SKILLS_DIR"/*/; do
   [ -d "$entry" ] || continue
   base="$(basename "$entry")"
-  case " $APP_PORTABLE " in
-    *" $base "*) : ;;                                   # already packaged
-    *) warn "$base: present but not app-portable (skipped)." ;;
-  esac
+  [ -f "$entry/SKILL.md" ] || { warn "$base: no SKILL.md, skipping."; continue; }
+  package_one "$base"
 done
 
 echo "[package-skills] done ($failures failure(s))"


### PR DESCRIPTION
## Why

The `morning-plan` skill was added but its zip never appeared on the `skills-latest` release. `ai/scripts/package_skills.sh` didn't auto-discover skills — it only zipped the ones named in a hardcoded `APP_PORTABLE` allowlist (`teach-me`, `jira-sprint-cleanup`), so any newly added skill was silently skipped.

## What changed

Per the request, the allowlist mechanism is removed entirely and **every** skill is packaged.

- **`ai/scripts/package_skills.sh`** — replace the `APP_PORTABLE` loop with auto-discovery: iterate over every `ai/skills/*/` directory that contains a `SKILL.md` and package it. Removed the now-obsolete "present but not app-portable (skipped)" reporting loop. Per-skill frontmatter validation is unchanged, so a skill with bad frontmatter still fails CI.
- **`mmm-deploy` / `update-repos`** are now packaged too. They're local-machine tools that won't function in the app/cloud sandbox; the docs note they'll upload fine but only work in local Claude Code.
- **Docs/comments** — updated the script header, the workflow comment, `.github/skills-release-notes.md`, and `ai/README.md` to drop the "app-portable subset" framing and describe "every skill is packaged."
- **`.gitignore`** — ignore `dist/` (the script's build output, which CI regenerates).

The loose `ai/skills/daily-ai-tools-digest.md` is a file (not a `*/` directory), so it's naturally ignored — no zip is produced for it.

## Verification

Ran `bash ai/scripts/package_skills.sh` locally:

```
[ok] jira-sprint-cleanup -> dist/jira-sprint-cleanup.zip
[ok] mmm-deploy          -> dist/mmm-deploy.zip
[ok] morning-plan        -> dist/morning-plan.zip
[ok] teach-me            -> dist/teach-me.zip
[ok] update-repos        -> dist/update-repos.zip
done (0 failure(s))   # exit 0
```

All 5 skills zip, including `morning-plan`; `unzip -l dist/morning-plan.zip` shows `morning-plan/SKILL.md` at the archive root; the loose note produced no zip. Once merged to `main` (or via a manual `workflow_dispatch` run), the Action uploads all five zips to the `skills-latest` release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FGKk3Xh9NN71aZiMMYee6n

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGKk3Xh9NN71aZiMMYee6n)_