### PR TITLE
Silence separators-epic rows and auto-revisit in morning-plan skill

### DIFF
--- a/ai/skills/morning-plan/SKILL.md
+++ b/ai/skills/morning-plan/SKILL.md
@@ -28,15 +28,22 @@ its tools are unavailable, say so and stop.
 - Bucket labels (exact strings): `daily-target`, `prioritize`, `aspirational`,
   `not-daily-goals`
 - Workflow transitions (global, verified): `11` = To Do, `31` = Done
-- Separator-looking tickets (summaries with `===` or similar) come in two kinds
-  — differentiate by parent epic, not by summary pattern:
-  - **Legacy visual separators**: children of epic `MCP-2213` ("separators").
-    Permanent. Exclude from triage; never label, close, or modify them.
-  - **Automation banner rows**: separator-style summaries NOT parented to
-    `MCP-2213` (created by Jira Automation). Also excluded from bucket triage,
-    but they are disposable clutter: list them in the final brief and close
-    them only if Mark says to — bulk cleanup belongs to his "clean up my jira
-    sprint" flow, not this one.
+- Separator / banner rows — structural rows that must NEVER be triaged.
+  Identify by parent epic, never by summary pattern:
+  - **Permanent structure — never surfaced.** Any child of epic `MCP-2213`
+    ("separators"). Exclude from triage and **never prompt, list, mention,
+    label, close, or modify** — no matter how banner-like the summary looks
+    (`^ Sunday (day)`, `===== ^ right after planning =====`,
+    `v ==== v new v ==== v`, etc.). Parentage is the only signal; summary text
+    is never a reason to surface one. (These are the same rows the
+    jira-sprint-cleanup skill calls its 6 permanent dividers — all now parented
+    to `MCP-2213`.)
+  - **Disposable automation banners**: separator-style summaries NOT parented to
+    `MCP-2213` (e.g. `DAILY AUTOMATION START/END` rows Jira Automation
+    regenerates). Also excluded from bucket triage; they are disposable clutter:
+    list them once in the final brief and close them only if Mark says to — bulk
+    cleanup belongs to his "clean up my jira sprint" flow, not this one. Never a
+    tap-prompt.
 
 ## Workflow
 
@@ -66,7 +73,10 @@ plan with whatever survives cleanup.
 
 Triage **every** open (not-done), non-separator item, whether or not it already
 carries a bucket label — nothing is carried over untouched; yesterday's labeled
-items get re-triaged fresh each run. Rules:
+items get re-triaged fresh each run. Re-triage is automatic and unconditional:
+**never ask Mark whether he wants to revisit or re-triage his not-done items —
+he always does.** Go straight into the item-by-item questions; never gate the
+interview behind a "want to revisit yesterday's items?" yes/no prompt. Rules:
 
 - Batches of **at most 3 items** per round, using tappable single-select
   options. Tap options cap at 4, so each question offers: **Daily target /
@@ -117,6 +127,9 @@ End with the day's plan, formatted for a phone screen:
 - **Daily target** — ordered quick-wins-first (lowest effort at top).
 - **Aspirational**, then **Not daily goals** — one line each.
 - Anything closed or skipped during the session.
+- Any disposable automation banners present (separator-style rows **not** under
+  `MCP-2213`) — listed once as clutter, closed only if Mark asks. Permanent
+  structure (children of `MCP-2213`) never appears here.
 - If `daily-target` exceeds ~5 items, say so once, plainly: "the less
   ambitious, the more achievable" — and name the best demotion candidates.
   Don't nag beyond that.
@@ -125,15 +138,17 @@ End with the day's plan, formatted for a phone screen:
 
 - Reads before writes; all label writes happen in step 3, transitions may
   happen mid-interview when Mark reports something done.
-- Never touch issues outside the open sprint; never modify legacy separators
-  (children of `MCP-2213`); close automation banner rows only on explicit
-  request; never edit Automation rules yourself (Mark does that in the Jira
-  UI).
+- Never touch issues outside the open sprint; never surface, prompt on, or
+  modify permanent structure (any child of `MCP-2213`); close disposable
+  automation banners only on explicit request; never edit Automation rules
+  yourself (Mark does that in the Jira UI).
 - Fine-grained order *within* a bucket is session-only. If Mark wants an
   artifact of the day's exact ordering, offer to write it as a comment on the
   `week planning ritual` ticket (or the topmost daily-target item) — don't do
   this unprompted.
-- Every not-done, non-separator item is re-triaged on every run: a stored
+- Every not-done, non-separator item is re-triaged on every run —
+  automatically, never gated behind a "want to revisit?" question. A stored
   bucket label neither suppresses the prompt nor pre-selects the answer (the
-  suggestion is recomputed from the effort heuristic each time). Separators and
-  automation banner rows remain excluded from triage per the rules above.
+  suggestion is recomputed from the effort heuristic each time). Permanent
+  structure (children of `MCP-2213`) and disposable automation banners remain
+  excluded from triage per the rules above.


### PR DESCRIPTION
Stops `morning-plan` from ever prompting about rows in the `MCP-2213` "separators" epic, and makes not-done re-triage unconditional.

## What changed (`ai/skills/morning-plan/SKILL.md`)

- **Separators-epic rows are now fully silent.** Any child of epic `MCP-2213` is permanent structure: never prompted, listed, mentioned, labeled, closed, or modified — no matter how banner-like the summary looks (`^ Sunday (day)`, `===== ^ right after planning =====`, `v ==== v new v ==== v`). Parentage is the only signal; summary text is never a reason to surface one.
- **Only out-of-epic banners stay disposable.** Separator-style rows NOT under `MCP-2213` (e.g. `DAILY AUTOMATION START/END` that Jira Automation regenerates) are still listed once in the final brief as clutter and closed only on request — never a tap-prompt. Bulk cleanup remains the `jira-sprint-cleanup` skill's job.
- **Re-triage is unconditional.** The interview never asks "want to revisit yesterday's items?" — it always re-triages every open non-structural item.

## Why

Previously the skill split separator-style rows by parentage but described the non-epic ones as "banner rows" and the epic ones as "legacy separators." Several epic children have banner-like summaries, so the model could misclassify them as disposable and prompt Mark to close them. Keying silence purely on `parent == MCP-2213` removes that failure.

## Design note

Mark moved `MCP-8954` under `MCP-2213`, so all six of `jira-sprint-cleanup`'s permanent dividers (`MCP-1193, MCP-1550, MCP-5493, MCP-6580, MCP-7207, MCP-8954`) are now epic children. Epic parentage alone is therefore sufficient — no hardcoded divider-key list is coupled into `morning-plan`, and the earlier cross-skill inconsistency (MCP-8954 outside the epic but treated as a divider) is resolved.

## Verification

Instruction-only change (no runtime to drive). Verified by reading the file end-to-end for coherence and tracing the current open sprint against the new rules: every `MCP-2213` child resolves to silent permanent structure; all `(...automation)` chores and real tasks triage as before; zero separator/banner rows are offered for closing. No Jira issues were mutated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JNt6nFEVHp7v1v9GzRjoME

---
_Generated by [Claude Code](https://claude.ai/code/session_01JNt6nFEVHp7v1v9GzRjoME)_