### PR TITLE
Require fresh Jira read before any state change in Jira skills

### DIFF
--- a/ai/skills/jira-sprint-cleanup/SKILL.md
+++ b/ai/skills/jira-sprint-cleanup/SKILL.md
@@ -105,10 +105,18 @@ you found. If no Done transition is available on that issue, **stop and report**
 
 ### 5. Transition the targets to Done
 
-For every key in the classifier's `CLOSE_ALL` list, call `transitionJiraIssue`
-with `cloudId`, `issueIdOrKey`, and `transition: {id: "<verified id>"}`.
-**Transition to Done -- never delete.** Leave Borderline items, real tasks,
-single-occurrence chores, and the 6 dividers alone.
+The plan can be stale: an arbitrary approval wait sits between the step-1 fetch
+and this mutation, and in that window Jira automation regenerates/closes rows
+and Mark may have closed some by hand. So for every key in the classifier's
+`CLOSE_ALL` list, **pull the issue's current state with `getJiraIssue`
+immediately before mutating it** and confirm the decision still holds against
+up-to-date state -- it must still be non-Done and still match what the plan
+classified (summary unchanged). Only then call `transitionJiraIssue` with
+`cloudId`, `issueIdOrKey`, and `transition: {id: "<verified id>"}`. If the fresh
+read contradicts the plan (already Done, or the summary changed so it is no
+longer clutter), **skip it and report** -- never transition against the stale
+plan. **Transition to Done -- never delete.** Leave Borderline items, real
+tasks, single-occurrence chores, and the 6 dividers alone.
 
 ### 6. Report
 
@@ -128,5 +136,9 @@ Borderline for me to handle). Then note the two things this does **not** fix:
 - Transition to Done, **never delete**.
 - **Plan first, mutate only after "go".** No exceptions.
 - **Surface ambiguity, never guess.** Borderline items are flagged, not closed.
+- **Verify state before writing.** The plan is built before an arbitrary
+  approval wait; re-read each target with `getJiraIssue` immediately before
+  closing it and skip anything whose current state no longer matches the plan
+  (already Done, summary changed). Never mutate against the stale snapshot.
 - Never touch the backlog, real tasks, or the 6 dividers.
 - A partial fetch is a wrong plan -- paginate to the last page before classifying.

--- a/ai/skills/morning-plan/SKILL.md
+++ b/ai/skills/morning-plan/SKILL.md
@@ -83,9 +83,10 @@ interview behind a "want to revisit yesterday's items?" yes/no prompt. Rules:
   Aspirational / Not daily goals / Mark as done**. `prioritize` stays a valid
   bucket via typed reply (it saw zero use in the first session — promote it
   back into the tap set if Mark starts using it).
-- **"Mark as done" is an action, not a label**: on selection, immediately
-  transition the issue to Done (`transitionJiraIssue`, id `31`) and write no
-  bucket label.
+- **"Mark as done" is an action, not a label**: on selection, first pull the
+  issue's current state (`getJiraIssue`) to confirm it isn't already Done or
+  otherwise changed (see **Verify state before writing**), then transition it
+  to Done (`transitionJiraIssue`, id `31`) and write no bucket label.
 - Embed a suggested bucket in each question, always computed from the heuristic
   below — independent of any bucket label the item already carries. A stored
   label never pre-selects the answer; it is only context. You may note an item's
@@ -110,8 +111,11 @@ interview behind a "want to revisit yesterday's items?" yes/no prompt. Rules:
 
 ### 3. Write labels (batched, after the interview)
 
-For each triaged open issue, set its bucket via `editJiraIssue` with
-`fields: {"labels": [...]}`.
+For each triaged open issue, first re-fetch its current state with
+`getJiraIssue` (see **Verify state before writing**), then set its bucket via
+`editJiraIssue` with `fields: {"labels": [...]}`. The fresh read is also what
+lets you honor the non-bucket-label exception below — you can only preserve a
+label that appeared since step 1 if you just read it.
 
 **Labels are owned by this system** — Mark does not use Jira labels for
 anything else. Set `labels` to exactly the one bucket label (the write replaces
@@ -138,6 +142,14 @@ End with the day's plan, formatted for a phone screen:
 
 - Reads before writes; all label writes happen in step 3, transitions may
   happen mid-interview when Mark reports something done.
+- **Verify state before writing**: the step-1 snapshot goes stale as the
+  interview runs — Jira Automation can re-create or close issues, and Mark may
+  edit in the Jira UI in parallel. Before *any* state change to an issue (a Done
+  transition in step 2 or a label write in step 3), pull that one issue's
+  current state with `getJiraIssue` and confirm the planned action still holds
+  against it. If the fresh state contradicts the decision (already Done, status
+  moved, an unexpected label present), surface the discrepancy and re-confirm
+  with Mark before writing — never act on the stale snapshot.
 - Never touch issues outside the open sprint; never surface, prompt on, or
   modify permanent structure (any child of `MCP-2213`); close disposable
   automation banners only on explicit request; never edit Automation rules


### PR DESCRIPTION
Add a **verify-state-before-writing** rule to both Jira skills: before mutating any Jira issue, re-read that issue's current state so the decision runs against up-to-date state — not a snapshot that has gone stale since it was fetched.

## Why
Both skills fetch state up front, then act later after a gap in which the snapshot can drift — Jira Automation re-creates/closes rows and Mark may edit in the Jira UI. Acting on the stale snapshot risks closing or re-labeling an issue whose real state already moved.
- **morning-plan**: the gap is the item-by-item interview between the step-1 read and the writes.
- **jira-sprint-cleanup**: the gap is the arbitrary approval wait — the skill prints a plan and blocks on Mark's "go" before transitioning.

## Changes

**`ai/skills/morning-plan/SKILL.md`**
- **New guardrail — "Verify state before writing":** before any state change (Done transition in step 2 or label write in step 3), pull the single issue with `getJiraIssue` and confirm the planned action still holds; on contradiction, surface it and re-confirm with Mark.
- Step 2 (Mark-as-done): re-fetch and confirm not-already-Done before `transitionJiraIssue`.
- Step 3 (label write): re-fetch before `editJiraIssue`; the fresh read also enables the existing non-bucket-label preservation exception.

**`ai/skills/jira-sprint-cleanup/SKILL.md`**
- **Step 5 (transition targets):** before closing each `CLOSE_ALL` target, pull it with `getJiraIssue` and confirm it's still non-Done and still matches the plan (summary unchanged); skip and report anything that no longer matches instead of transitioning against the stale plan.
- **New hard rule — "Verify state before writing"** mirroring the above.

Docs-only changes to skill `SKILL.md` files; no behavior code.

## Note (not in this diff)
The deployed copy at `~/.claude/skills/morning-plan/SKILL.md` is an older revision than this repo's source — a stale `mmm deploy`. Worth a re-deploy so the running skills match canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrtPyJ2VvWEsJhW4NKWvav