### PR TITLE
Add mos cask to one-time Homebrew setup

### DIFF
--- a/one-time-config.sh
+++ b/one-time-config.sh
@@ -13,3 +13,10 @@ else
   echo "Error: Homebrew not found; cannot install cloc. Install brew first: https://brew.sh" >&2
 fi
 
+# GUI apps
+if command -v brew &> /dev/null; then
+  brew install --cask mos
+else
+  echo "Error: Homebrew not found; cannot install mos. Install brew first: https://brew.sh" >&2
+fi
+


### PR DESCRIPTION
Installs [mos](https://github.com/Caldis/Mos) (menu-bar scroll smoothing) via `brew install --cask mos` in `one-time-config.sh`.

- **New section**: "GUI apps" block, mirroring the existing CLI-tools brew-check pattern.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PxvSeetRa4cceUoajAgYVn)_