### PR TITLE
Make Mark's categorization final in morning-plan — flag, never pause

### DIFF
--- a/ai/skills/morning-plan/SKILL.md
+++ b/ai/skills/morning-plan/SKILL.md
@@ -106,7 +106,11 @@ interview behind a "want to revisit yesterday's items?" yes/no prompt. Rules:
   - Time-pinned items (due today, "(Sunday automation)" on a Sunday) lean
     `daily-target`; blocked or deferred-dependency items lean
     `not-daily-goals`.
-  - Mark overrides freely — his answer always wins over the heuristic.
+  - **Mark's answer is final — never second-guess his categorization.** His
+    choice always wins over the heuristic. Never pause the interview to ask
+    whether a bucket is "right" or whether he did something correctly — record
+    the answer and move to the next item. If a choice looks wrong, hold it for
+    the flags line at the top of the final brief (step 4): flag, never block.
 - Handle free-text answers, not just taps:
   - "done" / "I did it" / "wife owns it now" → same as tapping "Mark as done".
     Whenever an issue is closed this way and its summary carries an
@@ -136,7 +140,13 @@ error, and continue with the rest — no silent failures.
 
 Formatted for a phone screen, in this order:
 
-- **Closed this session** — print this summary *first*, before the day's plan.
+- **Flags (optional — only if something looks off)** — the very first lines of
+  the brief, above everything else. One or two lines noting anything that looks
+  miscategorized or wrong from the interview. This is a heads-up, not a gate: it
+  never appears mid-interview and never pauses anything. Omit the line entirely
+  if nothing looks off — never manufacture a flag.
+- **Closed this session** — print this summary right after any flags line and
+  before the day's plan.
   Cover everything closed this run, from both sources: duplicates and banners
   closed by the auto-invoked jira-sprint-cleanup (step 1), and items Mark marked
   done during the interview. One line each (key + summary). If nothing was
@@ -166,6 +176,13 @@ Then the day's plan:
   against it. If the fresh state contradicts the decision (already Done, status
   moved, an unexpected label present), surface the discrepancy and re-confirm
   with Mark before writing — never act on the stale snapshot.
+- **Never second-guess Mark's categorization, and never pause to ask if he did
+  something right.** His bucket choices are final; record them and keep going.
+  Anything that looks wrong goes on the optional flags line at the top of the
+  final brief (step 4) — flag it there, never block on it. This governs his
+  judgment only; it does not relax **Verify state before writing**, whose pause
+  is triggered by a genuine state race (an issue Jira changed underneath the
+  snapshot), not by second-guessing his choice.
 - Never touch issues outside the open sprint; never surface, prompt on, or
   modify permanent structure (any child of `MCP-2213`); close disposable
   automation banners only on explicit request; never edit Automation rules

--- a/ai/skills/morning-plan/SKILL.md
+++ b/ai/skills/morning-plan/SKILL.md
@@ -83,14 +83,16 @@ items get re-triaged fresh each run. Re-triage is automatic and unconditional:
 he always does.** Go straight into the item-by-item questions; never gate the
 interview behind a "want to revisit yesterday's items?" yes/no prompt. Rules:
 
-- Batches of **at most 6 items** per round, using tappable single-select
-  options. Two different caps apply: each *question* offers at most 4 options —
-  **Daily target / Aspirational / Not daily goals / Mark as done** — and each
-  tappable prompt (`AskUserQuestion`) holds at most 4 *questions*. So a round of
-  6 cannot be a single prompt: deliver it as two consecutive tap-prompts (e.g.
-  3+3), then pause for the next round of 6. `prioritize` stays a valid bucket
-  via typed reply (it saw zero use in the first session — promote it back into
-  the tap set if Mark starts using it).
+- **Six items per round — always aim for the full 6, never stop at 3.** The
+  `AskUserQuestion` tool caps at 4 *questions* per prompt, so 6 items cannot fit
+  in one card. Deliver each round as **two back-to-back tap-prompts — 4 then 2**
+  (fall back to 3+3 only if needed). Fire the second prompt *immediately* after
+  the first is answered: **do not pause, summarize, or wait between the two
+  halves — the two prompts are one round of 6.** Only after all 6 are answered
+  do you move on to the next round of 6. Each *question* offers at most 4
+  options — **Daily target / Aspirational / Not daily goals / Mark as done**.
+  `prioritize` stays a valid bucket via typed reply (it saw zero use in the
+  first session — promote it back into the tap set if Mark starts using it).
 - **"Mark as done" is an action, not a label**: on selection, first pull the
   issue's current state (`getJiraIssue`) to confirm it isn't already Done or
   otherwise changed (see **Verify state before writing**), then transition it


### PR DESCRIPTION
The morning-plan skill now treats Mark's bucket choices as final: it never second-guesses a categorization and never pauses mid-interview to ask if he did something right. Anything that looks wrong is flagged, not blocked.

- **Interview rule**: replaced "Mark overrides freely" with a stronger rule — his answer is final, never pause to ask whether a bucket is "right"; record and move on. A wrong-looking choice is held for the final brief, never surfaced as a question.
- **Final brief**: added an optional flags line as the very first lines of the brief (above "Closed this session"). Present only when something looks off; a heads-up, never a gate. Omit entirely if nothing looks off.
- **Guardrail**: codified "never second-guess, never pause" and scoped it to Mark's judgment only. It explicitly does **not** relax `Verify state before writing`, whose pause is triggered by a real state race (Jira changed an issue underneath the step-1 snapshot), not by second-guessing his choice.

Single-file change: `ai/skills/morning-plan/SKILL.md`. Deploy to the live tools is a separate `mmm deploy` step, not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGmgv8XryLtcMKv9S1jaiZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGmgv8XryLtcMKv9S1jaiZ)_