### PR TITLE
Require at least 4 items per triage prompt in morning-plan

### DIFF
--- a/ai/skills/morning-plan/SKILL.md
+++ b/ai/skills/morning-plan/SKILL.md
@@ -97,9 +97,11 @@ items get re-triaged fresh each run. Re-triage is automatic and unconditional:
 he always does.** Go straight into the item-by-item questions; never gate the
 interview behind a "want to revisit yesterday's items?" yes/no prompt. Rules:
 
-- Deliver the triage as tappable single-select prompts, each filled to **the
-  maximum number of questions the AskUserQuestion prompt allows** (currently
-  4) — never split a batch into smaller prompts than that cap forces. Each
+- Deliver the triage as tappable single-select prompts. **Fill every prompt
+  to the maximum number of questions AskUserQuestion allows. As of this
+  writing the max is 4, so include at least 4 items per prompt** — fewer only
+  when fewer than 4 remain in the queue. Never send a 3-item prompt when a
+  4th item is waiting. Each
   *question* offers at most 4 options — **Daily target / Aspirational / Not
   daily goals / Mark as done**. Pause for Mark's answers after each prompt,
   then continue with the next full prompt until the queue is done.


### PR DESCRIPTION
Morning-plan triage prompts were still arriving 3 items at a time; this restates the batch rule as an explicit floor so prompts fill to the AskUserQuestion cap.

- **Explicit number**: the rule now reads "As of this writing the max is 4, so include at least 4 items per prompt" instead of the soft parenthetical "(currently 4)" added in 093226d, which under-filled in practice.
- **Verified max**: the AskUserQuestion tool schema allows 1–4 questions per call (`maxItems: 4`), so 4 is the correct batch size.
- **Explicit exception**: fewer than 4 only when fewer than 4 items remain in the queue.

One wording change in the first bullet of §2 Interview in `ai/skills/morning-plan/SKILL.md`; no other file states a batch size.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKCUXYMEHS5kH3NycAZWjy)_