### PR TITLE
Add Claude Code status line script and installer

### DIFF
--- a/ai/README.md
+++ b/ai/README.md
@@ -21,8 +21,16 @@ ai/
 │   ├── update-repos/            # local-machine tool (operates on local git repos)
 │   └── daily-ai-tools-digest.md # loose note, NOT a skill (no <name>/SKILL.md dir)
 ├── cloud-setup.sh               # Cloud Code setup script: copies AGENTS.md + skills into ~/.claude
+├── statusline.py                # Claude Code CLI status line; NOT a skill (see below)
 └── scripts/package_skills.sh    # builds claude.ai-app-ready skill ZIPs
 ```
+
+**Why `statusline.py` sits here and not in `skills/`:** everything under
+`skills/` is auto-published — `package_skills.sh` zips every `<name>/SKILL.md`
+directory with no allowlist, and `cloud-setup.sh` copies the whole tree into
+cloud sessions. The status line is a local macOS terminal feature that would be
+dead weight (or confusing) on those surfaces, so it deliberately lives one level
+up as a sibling of `skills/`, where neither script globs it.
 
 ## How each surface gets its skills
 
@@ -108,3 +116,12 @@ Consequences accepted:
   instructions for app chats (no upload API for that surface).
 - **`morning-plan`** (planning ritual + sprint cleanup mode) needs the Atlassian connector enabled in whatever chat runs it.
 - **`daily-ai-tools-digest.md`** is a loose note, not a skill; nothing packages or ships it.
+- **`statusline.py`** covers exactly one surface: the **Claude Code CLI on macOS**.
+  It is not distributed by `mmm` (which handles only context, skills, and
+  subagents) and does not apply to the claude.ai app or cloud sessions. It is
+  installed by `one-time-config.sh` at the repo root, which symlinks it to
+  `~/.claude/statusline.py` and sets `statusLine` in `~/.claude/settings.json`.
+  Because it is a **symlink**, edits here are live with no redeploy — but the
+  clone must stay at a stable path. Note `~/.claude/settings.json` is separately
+  snapshotted to the Riot dotfiles repo by the `backup-claude-settings` skill;
+  that backup captures the *setting* but not this *script*.

--- a/ai/statusline.py
+++ b/ai/statusline.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Claude Code status line for macOS."""
+
+import json
+import os
+import subprocess
+import sys
+
+
+ESC = "\x1b"
+RESET = f"{ESC}[0m"
+DIM = f"{ESC}[90m"
+SEP = f"{DIM}│{RESET}"
+
+
+def fg(red, green, blue):
+    return f"{ESC}[38;2;{red};{green};{blue}m"
+
+
+def nested(data, *keys, default=None):
+    value = data
+    for key in keys:
+        if not isinstance(value, dict):
+            return default
+        value = value.get(key)
+    return default if value is None else value
+
+
+def context_part(data):
+    used = nested(data, "context_window", "used_percentage")
+    if used is None:
+        return f"{DIM}ctx n/a{RESET}"
+
+    used = round(float(used))
+    free = 100 - used
+    width = 14
+    fill = max(0, min(width, round(width * used / 100)))
+    bar = []
+    for index in range(width):
+        if index >= fill:
+            bar.append(f"{fg(60, 60, 60)}░")
+            continue
+        position = (index + 0.5) / width * 100
+        if position <= 50:
+            ratio = position / 50
+            color = fg(int(220 * ratio), 200, int(80 - 80 * ratio))
+        else:
+            ratio = (position - 50) / 50
+            color = fg(220, int(200 - 160 * ratio), int(20 * ratio))
+        bar.append(f"{color}█")
+
+    if used >= 90:
+        icon = "🚨"
+    elif used >= 70:
+        icon = "🔥"
+    elif used >= 20:
+        icon = "⚡"
+    else:
+        icon = "🟢"
+    return f"{icon} {''.join(bar)}{RESET} {DIM}{free:.0f}% free{RESET}"
+
+
+def git_branch(data):
+    directory = nested(data, "workspace", "current_dir") or data.get("cwd")
+    if not directory:
+        return ""
+    environment = os.environ.copy()
+    environment["GIT_OPTIONAL_LOCKS"] = "0"
+    for command in (("branch", "--show-current"), ("rev-parse", "--short", "HEAD")):
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(directory), *command],
+                text=True,
+                capture_output=True,
+                timeout=1,
+                env=environment,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return ""
+        value = result.stdout.strip()
+        if result.returncode == 0 and value:
+            return value
+    return ""
+
+
+def render(data):
+    cost = float(nested(data, "cost", "total_cost_usd", default=0) or 0)
+    cost_text = f"${cost:.3f}" if 0 < cost < 0.01 else f"${cost:.2f}"
+    cost_part = f"{fg(220, 200, 0)}SESSION {cost_text}{RESET}"
+
+    added = int(nested(data, "cost", "total_lines_added", default=0) or 0)
+    removed = int(nested(data, "cost", "total_lines_removed", default=0) or 0)
+    velocity = f"{fg(0, 200, 80)}+{added}{RESET} {fg(220, 40, 20)}-{removed}{RESET}"
+
+    parts = [cost_part, context_part(data)]
+    branch = git_branch(data)
+    if branch:
+        parts.append(f"{fg(190, 130, 255)}{branch}{RESET}")
+    parts.append(velocity)
+    return f" {SEP} ".join(parts)
+
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+        if isinstance(data, dict):
+            print(render(data))
+    except (TypeError, ValueError, OSError):
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/one-time-config.sh
+++ b/one-time-config.sh
@@ -20,3 +20,81 @@ else
   echo "Error: Homebrew not found; cannot install mos. Install brew first: https://brew.sh" >&2
 fi
 
+# Claude Code status line (macOS only)
+#
+# Symlinks ai/statusline.py into ~/.claude and points Claude Code's statusLine
+# setting at it. The symlink means edits to the repo copy are live immediately --
+# no redeploy -- so THIS CLONE MUST LIVE AT A STABLE PATH. Moving or deleting it
+# breaks the status line. (This is the first part of this script that depends on
+# where the repo is checked out; everything above is location-independent.)
+#
+# Safe to re-run: ln -sfn replaces whatever is there, and the settings.json patch
+# rewrites a single key to the same value.
+STATUSLINE_SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/ai/statusline.py"
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "Note: not macOS; skipping Claude Code status line." >&2
+elif [ ! -f "$STATUSLINE_SRC" ]; then
+  echo "Error: status line script not found at $STATUSLINE_SRC; skipping." >&2
+else
+  # Prefer Apple's system python3 (always present on macOS, no venv surprises).
+  if [ -x /usr/bin/python3 ]; then
+    STATUSLINE_PY=/usr/bin/python3
+  else
+    STATUSLINE_PY="$(command -v python3 2>/dev/null)"
+  fi
+
+  if [ -z "$STATUSLINE_PY" ]; then
+    echo "Error: python3 not found; skipping Claude Code status line." >&2
+  else
+    mkdir -p "$HOME/.claude"
+    # -f replaces an existing real file; -n avoids linking INTO the old symlink's
+    # target directory when re-running.
+    ln -sfn "$STATUSLINE_SRC" "$HOME/.claude/statusline.py"
+
+    # Add ONLY the statusLine key, preserving every other setting. Written to a
+    # temp file in the same directory and os.replace'd so a crash mid-write can
+    # never leave a truncated settings.json (which would silently disable ALL
+    # settings from that file).
+    "$STATUSLINE_PY" - "$STATUSLINE_PY" <<'PY'
+import json, os, sys, tempfile
+
+interpreter = sys.argv[1]
+path = os.path.expanduser("~/.claude/settings.json")
+command = "%s %s/.claude/statusline.py" % (interpreter, os.path.expanduser("~"))
+
+data = {}
+if os.path.exists(path):
+    try:
+        with open(path) as handle:
+            data = json.load(handle)
+    except ValueError as error:
+        sys.exit(
+            "Error: %s is not valid JSON (%s); leaving it alone. "
+            "Fix it by hand, then re-run this script." % (path, error)
+        )
+    if not isinstance(data, dict):
+        sys.exit("Error: %s is not a JSON object; leaving it alone." % path)
+
+data["statusLine"] = {"type": "command", "command": command}
+
+directory = os.path.dirname(path)
+descriptor, temporary = tempfile.mkstemp(dir=directory, prefix=".settings.json.")
+try:
+    with os.fdopen(descriptor, "w") as handle:
+        json.dump(data, handle, indent=2)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.chmod(temporary, 0o644)
+    os.replace(temporary, path)
+except BaseException:
+    if os.path.exists(temporary):
+        os.unlink(temporary)
+    raise
+
+print("Claude Code status line installed: %s" % command)
+PY
+  fi
+fi
+


### PR DESCRIPTION
The status line lived only on my laptop. backup-claude-settings snapshots settings.json to the Riot repo, but not statusline.py -- so a restore produced a statusLine setting pointing at a script that did not exist. This closes that gap; nothing about the status line is Riot-specific.

- **ai/statusline.py**: canonical copy. Deliberately a sibling of ai/skills/, not inside it -- package_skills.sh and cloud-setup.sh glob that directory with no allowlist, and a macOS-only status line should not ship to the claude.ai app or cloud sessions.
- **one-time-config.sh**: symlinks the script into ~/.claude and adds only the statusLine key to settings.json via a same-directory temp file plus os.replace, so a crash mid-write cannot truncate the file. Guarded on macOS and python3, idempotent, bash 3.2 compatible.

Tradeoff: a symlink means repo edits are live with no redeploy, but this clone must stay at a stable path -- moving it breaks the status line. This is the first part of one-time-config.sh that depends on the checkout location.