### PR TITLE
Add Claude Code status line script and install prompt

### DIFF
--- a/ai/README.md
+++ b/ai/README.md
@@ -21,8 +21,16 @@ ai/
 │   ├── update-repos/            # local-machine tool (operates on local git repos)
 │   └── daily-ai-tools-digest.md # loose note, NOT a skill (no <name>/SKILL.md dir)
 ├── cloud-setup.sh               # Cloud Code setup script: copies AGENTS.md + skills into ~/.claude
+├── statusline/                  # Claude Code CLI status line — NOT a skill
+│   ├── statusline.py            #   the script itself
+│   └── INSTALL_PROMPT.md        #   paste into Claude Code to install it
 └── scripts/package_skills.sh    # builds claude.ai-app-ready skill ZIPs
 ```
+
+`statusline/` is a sibling of `skills/`, not inside it, on purpose: everything
+under `skills/` is auto-zipped by `package_skills.sh` and copied into cloud
+sessions by `cloud-setup.sh`, and a macOS-only status line has no business on
+those surfaces.
 
 ## How each surface gets its skills
 
@@ -108,3 +116,11 @@ Consequences accepted:
   instructions for app chats (no upload API for that surface).
 - **`morning-plan`** (planning ritual + sprint cleanup mode) needs the Atlassian connector enabled in whatever chat runs it.
 - **`daily-ai-tools-digest.md`** is a loose note, not a skill; nothing packages or ships it.
+- **`statusline/`** targets one surface only: the Claude Code CLI on macOS. `mmm`
+  does not distribute it (it handles context, skills, and subagents). To install
+  on a new Mac, paste the prompt in `statusline/INSTALL_PROMPT.md` into Claude
+  Code from that directory. On this machine `~/.claude/statusline.py` is a
+  symlink back to `statusline/statusline.py`, so edits here are live — but that
+  means the clone must stay put. The `statusLine` *setting* also rides along in
+  the Riot repo's `settings.json` backup; the *script* does not, which is why it
+  lives here.

--- a/ai/statusline/INSTALL_PROMPT.md
+++ b/ai/statusline/INSTALL_PROMPT.md
@@ -1,0 +1,30 @@
+# Install this Claude Code status line on macOS
+
+Copy and paste the prompt below into Claude Code or another coding assistant while `statusline.py` is available in the same folder.
+
+```text
+Install the attached `statusline.py` as my Claude Code status line on macOS.
+
+Requirements:
+1. Confirm this is macOS and that `python3` is available. Stop with a clear explanation if either check fails.
+2. Copy `statusline.py` to `~/.claude/statusline.py` and make it executable.
+3. Keep the cost field labeled in uppercase as `SESSION $1.23` so recipients know it is cumulative for the current Claude Code session, not the last message or Git commit.
+4. Preserve every existing field in `~/.claude/settings.json`. Create the file as an empty JSON object only if it does not exist.
+5. Add or replace only this setting, using the recipient's resolved absolute home-directory path in the command:
+
+   "statusLine": {
+     "type": "command",
+     "command": "/usr/bin/python3 /ABSOLUTE/HOME/.claude/statusline.py"
+   }
+
+   If `/usr/bin/python3` does not exist, use the absolute path returned by `command -v python3`.
+6. Update the JSON atomically and keep it valid. Do not overwrite, reformat manually, or remove unrelated settings.
+7. Verify:
+   - the script passes Python syntax compilation with its bytecode cache redirected to `/tmp`;
+   - the installed script is executable;
+   - `settings.json` parses as JSON and contains the exact `statusLine` command;
+   - piping representative Claude status JSON into the script prints cost, a 14-character context bar, percent free, Git branch when available, and added/removed line counts.
+8. Report the installed paths and verification results. Do not commit or modify any project repository.
+
+Restart Claude Code after installation so it reloads the setting.
+```

--- a/ai/statusline/statusline.py
+++ b/ai/statusline/statusline.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Claude Code status line for macOS."""
+
+import json
+import os
+import subprocess
+import sys
+
+
+ESC = "\x1b"
+RESET = f"{ESC}[0m"
+DIM = f"{ESC}[90m"
+SEP = f"{DIM}│{RESET}"
+
+
+def fg(red, green, blue):
+    return f"{ESC}[38;2;{red};{green};{blue}m"
+
+
+def nested(data, *keys, default=None):
+    value = data
+    for key in keys:
+        if not isinstance(value, dict):
+            return default
+        value = value.get(key)
+    return default if value is None else value
+
+
+def context_part(data):
+    used = nested(data, "context_window", "used_percentage")
+    if used is None:
+        return f"{DIM}ctx n/a{RESET}"
+
+    used = round(float(used))
+    free = 100 - used
+    width = 14
+    fill = max(0, min(width, round(width * used / 100)))
+    bar = []
+    for index in range(width):
+        if index >= fill:
+            bar.append(f"{fg(60, 60, 60)}░")
+            continue
+        position = (index + 0.5) / width * 100
+        if position <= 50:
+            ratio = position / 50
+            color = fg(int(220 * ratio), 200, int(80 - 80 * ratio))
+        else:
+            ratio = (position - 50) / 50
+            color = fg(220, int(200 - 160 * ratio), int(20 * ratio))
+        bar.append(f"{color}█")
+
+    if used >= 90:
+        icon = "🚨"
+    elif used >= 70:
+        icon = "🔥"
+    elif used >= 20:
+        icon = "⚡"
+    else:
+        icon = "🟢"
+    return f"{icon} {''.join(bar)}{RESET} {DIM}{free:.0f}% free{RESET}"
+
+
+def git_branch(data):
+    directory = nested(data, "workspace", "current_dir") or data.get("cwd")
+    if not directory:
+        return ""
+    environment = os.environ.copy()
+    environment["GIT_OPTIONAL_LOCKS"] = "0"
+    for command in (("branch", "--show-current"), ("rev-parse", "--short", "HEAD")):
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(directory), *command],
+                text=True,
+                capture_output=True,
+                timeout=1,
+                env=environment,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return ""
+        value = result.stdout.strip()
+        if result.returncode == 0 and value:
+            return value
+    return ""
+
+
+def render(data):
+    cost = float(nested(data, "cost", "total_cost_usd", default=0) or 0)
+    cost_text = f"${cost:.3f}" if 0 < cost < 0.01 else f"${cost:.2f}"
+    cost_part = f"{fg(220, 200, 0)}SESSION {cost_text}{RESET}"
+
+    added = int(nested(data, "cost", "total_lines_added", default=0) or 0)
+    removed = int(nested(data, "cost", "total_lines_removed", default=0) or 0)
+    velocity = f"{fg(0, 200, 80)}+{added}{RESET} {fg(220, 40, 20)}-{removed}{RESET}"
+
+    parts = [cost_part, context_part(data)]
+    branch = git_branch(data)
+    if branch:
+        parts.append(f"{fg(190, 130, 255)}{branch}{RESET}")
+    parts.append(velocity)
+    return f" {SEP} ".join(parts)
+
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+        if isinstance(data, dict):
+            print(render(data))
+    except (TypeError, ValueError, OSError):
+        pass
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
backup-claude-settings snapshots settings.json to the Riot repo but not statusline.py, so a restore produced a statusLine setting pointing at a script that did not exist. This stores the script itself. Nothing about it is Riot-specific.

- **ai/statusline/statusline.py**: the script.
- **ai/statusline/INSTALL_PROMPT.md**: the prompt that installs it — paste into Claude Code from that directory. Ships with the script rather than a hand-rolled shell installer, so there is one install path to keep correct.

Placed as a sibling of ai/skills/, not inside it: package_skills.sh and cloud-setup.sh glob that directory with no allowlist, and a macOS-only status line should not ship to the claude.ai app or cloud sessions.